### PR TITLE
Fix link for longest open issue

### DIFF
--- a/page.tpl
+++ b/page.tpl
@@ -317,7 +317,7 @@ This shows the longest opened issue closed during Closember.
   <td>{{loop.index}} </td>
   <td ><a href='https://github.com/{{item.repo}}'>{{item.repo}}<a></td>
   <td class='green-glow' title='opened on {{item.open}} – closed on {{item.close}} – opened for {{item.delta}} '>{{item.delta|naturaldelta}}</td>
-  <td ><a href='{item.url}'>{{item.repo}}#{{item.number}}</td>
+  <td ><a href='{{item.url}}'>{{item.repo}}#{{item.number}}</td>
 </tr>
 {% endfor %}
 </table>


### PR DESCRIPTION
A tiny fix for the link in `Longest open issue` rows, which currently returns:
```html
<tr>
  <td>1 </td>
  <td ><a href='https://github.com/ipython/ipython'>ipython/ipython<a></td>
  <td class='green-glow' title='opened on 2011-04-07 09:09:42+00:00 – closed on  – opened for 3806 days, 16:30:21 '>10 years</td>
  <td ><a href='{item.url}'>ipython/ipython#333</td>
</tr>
```
