### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,12 @@
 
 See https://closember.org
 
-## run locally 
+## build locally 
 
 ```
-$ pip install -r requirements.txt
+$ pip install -r requirements.lock
 $ export PAT="github personal access token"
-$ python -m app.py
+$ python app.py static
 ```
+
+Open the built page at `build/index.html`.


### PR DESCRIPTION
Seems like we should be recommending people use the lockfile.

Also, `app.py` isn't a package, it can't be run with `-m`. Needs to be bare `python app.py`

I also think it might be best just to recommend a static local build.