### PR TITLE
Fix code typo and disable workflow on cron trigger in forks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,9 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
+    # Only run on the cron timer for the openteamsinc/closember repo itself
+    if: github.repository == 'openteamsinc/closember' || ! contains(github.event_name, 'cron')
+
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -32,6 +35,7 @@ jobs:
       - name: Run a multi-line script
         shell: "bash -l {0}"
         run: |
+          echo Triggered by ${{ github.event_name }}.
           conda create -n 39 python==3.9
           conda activate 39
           pip install -r requirements.lock
@@ -40,8 +44,6 @@ jobs:
           PAT: ${{ secrets.GITHUB_TOKEN }}
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@3.5.9
-        # Only deploy cronjob from main branch & repo
-        if: success() && github.ref == 'refs/heads/main' && github.repository_owner == 'openteamsinc'
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: gh-pages # The branch the action should deploy to.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,8 @@ jobs:
           PAT: ${{ secrets.GITHUB_TOKEN }}
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@3.5.9
-        if: success() && github.ref == 'refs/heads/main'  # Only deploy cronjob from main
+        # Only deploy cronjob from main branch & repo
+        if: success() && github.ref == 'refs/heads/main' && github.repository_owner == 'openteamsinc'
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: gh-pages # The branch the action should deploy to.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup Miniconda
         uses: conda-incubator/setup-miniconda@master

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,6 +40,7 @@ jobs:
           PAT: ${{ secrets.GITHUB_TOKEN }}
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@3.5.9
+        if: success() && github.ref == 'refs/heads/main'  # Only deploy cronjob from main
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: gh-pages # The branch the action should deploy to.

--- a/app.py
+++ b/app.py
@@ -149,7 +149,7 @@ async def run_query(
         else:
             raise Exception(
                 "Query failed to run by returning code of {}. {} | {}".format(
-                    request.status_code, q, requests.content
+                    request.status_code, q, request.content
                 )
             )
     else:


### PR DESCRIPTION
Deploy step only to occur on `main` branch, and on the `openteamsinc` repo. (**NOTE:** This has been changed, see [below](https://github.com/openteamsinc/closember/pull/25#issuecomment-1293524891).)

Also update workflow to the current `checkout` action version.

Also fix a code typo that was breaking the workflow. (Unclear to me if execution reaching the code path where the typo was present means that something serious is going wrong with the queries.)