### PR TITLE
Switch to explicit UTC page timestamp

### DIFF
--- a/app.py
+++ b/app.py
@@ -537,7 +537,7 @@ async def render():
         other=other,
         CUT_DATE=CUT_DATE,
         ONGOING=ONGOING,
-        NOW=datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+        NOW=datetime.datetime.utcnow().strftime("%d %b %Y %H:%M:%S UTC"),
         sg_total=sg_total,
         top_sg=top_sg,
         svg=svg,


### PR DESCRIPTION
Also use text month name for minimum ambiguity. 

Sample:

<img width="224" alt="image" src="https://user-images.githubusercontent.com/11325439/199343023-8173befe-9160-4c8d-b2d5-e3d03f45ee2f.png">
